### PR TITLE
Fixed Not Eating if Dish Already In Front of Them

### DIFF
--- a/scenes/cutscene.tscn
+++ b/scenes/cutscene.tscn
@@ -237,6 +237,56 @@ tracks/4/keys = {
 "values": [Vector2(402, 393), Vector2(402, 381), Vector2(402, 393)]
 }
 
+[sub_resource type="Animation" id="Animation_3ptll"]
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Characters/Susan:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(402, 393), Vector2(402, 900)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("UI/Panel:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(346, 451), Vector2(346, 651)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("tutorialbox:position")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0.133333, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(588, -287), Vector2(588, 317)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("tutorialbox:visible")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0.0333333),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+
 [sub_resource type="Animation" id="Animation_ho0y6"]
 length = 0.001
 tracks/0/type = "value"
@@ -362,56 +412,6 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
 "values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
-}
-
-[sub_resource type="Animation" id="Animation_3ptll"]
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("Characters/Susan:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.2),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector2(402, 393), Vector2(402, 900)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("UI/Panel:position")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.2),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector2(346, 451), Vector2(346, 651)]
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("tutorialbox:position")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0.133333, 0.5),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector2(588, -287), Vector2(588, 317)]
-}
-tracks/3/type = "value"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath("tutorialbox:visible")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0.0333333),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [true]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_pduvj"]

--- a/scripts/spinningthing.gd
+++ b/scripts/spinningthing.gd
@@ -12,7 +12,6 @@ extends Node2D
 
 # --- Physics Properties ---
 @export var max_scale: float = 1.2
-@export var serving_distance_threshold_radians: float = 30.0 * (PI / 180.0)
 var angular_velocity: float = 0.0
 const acceleration: float = 5.0
 const max_angular_velocity: float = 7.0
@@ -107,34 +106,14 @@ func spawn_npcs():
 # --- Event Functions ---
 func _on_susan_stopped():
 	#print("Susan stopped! Checking dishes...")
-	var dishes = []
 	var npcs = []
 	for node in get_children():
-		if node is Dish:
-			dishes.append(node)
-		elif node is NPC:
+		if node is NPC:
 			npcs.append(node)
 	# for each npc calculate what to do with dish
 	for npc in npcs:
-		# distance between dish and npc
-		var closest_dish: Dish = null
-		var min_angle_diff = INF
-		for dish in dishes:
-			var diff = abs(angle_difference(npc.placement_angle, dish.current_angle))
-			if diff < min_angle_diff:
-				min_angle_diff = diff
-				closest_dish = dish
-		# find desired dish nearby
-		if closest_dish:
-			var diff = abs(angle_difference(npc.placement_angle, closest_dish.current_angle))
-			var can_eat = false
-			# Check all conditions: close enough, correct item, dish has quantity, and npc is not full
-			if diff < serving_distance_threshold_radians and closest_dish.quantity > 0:
-				if closest_dish.item_name == npc.desired_item_name and npc.satiation < npc.MAX_SATIATION:
-					can_eat = true
-			if can_eat and closest_dish.start_consumption(npc.consumption_timer, npc):
-				npc.start_eating()
-	
+		npc.look_for_dish()
+			
 	# for npc in npcs:
 	# 	var half_width: float = (serving_distance_threshold_radians) * 0.5
 	# 	var start_angle: float = npc.placement_angle - half_width


### PR DESCRIPTION
If an NPC starts wanting a dish and the dish is already in front of them, it originally wouldn't eat it.

Did some refactoring to move the dish-NPC distance into the NPC script and had it look for a dish when it first gets a desire if the susan is currently stopped.